### PR TITLE
Updated table view upon schema selection

### DIFF
--- a/PostgresGUI/Views/Sidebar/ConnectionsDatabasesSidebar.swift
+++ b/PostgresGUI/Views/Sidebar/ConnectionsDatabasesSidebar.swift
@@ -142,6 +142,7 @@ struct ConnectionsDatabasesSidebar: View {
         TablesListIsolated(
             tables: appState.connection.filteredTables,
             groupedTables: appState.connection.groupedTables,
+            selectedSchema: appState.connection.selectedSchema,
             selectedTable: Binding(
                 get: { appState.connection.selectedTable },
                 set: { appState.connection.selectedTable = $0 }

--- a/PostgresGUI/Views/Tables/TablesListView.swift
+++ b/PostgresGUI/Views/Tables/TablesListView.swift
@@ -17,6 +17,7 @@ struct TablesListView: View {
         TablesListIsolated(
             tables: appState.connection.filteredTables,
             groupedTables: appState.connection.groupedTables,
+            selectedSchema: appState.connection.selectedSchema,
             selectedTable: Binding(
                 get: { appState.connection.selectedTable },
                 set: { appState.connection.selectedTable = $0 }
@@ -39,6 +40,7 @@ struct TablesListView: View {
 struct TablesListIsolated: View {
     let tables: [TableInfo]
     let groupedTables: [SchemaGroup]
+    let selectedSchema: String?  // nil means "All Schemas"
     @Binding var selectedTable: TableInfo?
     @Binding var expandedSchemas: Set<String>
     let isLoadingTables: Bool
@@ -85,7 +87,8 @@ struct TablesListIsolated: View {
             TableListRowView(
                 table: table,
                 isExecutingQuery: isExecutingQuery,
-                refreshQueryAction: refreshQueryAction
+                refreshQueryAction: refreshQueryAction,
+                showSchemaPrefix: selectedSchema == nil
             )
             .tag(table)
             .listRowSeparator(.visible)


### PR DESCRIPTION
When viewing a DB in PostgresGUI, the various schemas can be selected from the sidebar view pane and the tables assigned to each schema show up with just their table name (e.g., public.test_table just shows up as `test_table` under the drop-down labeled `public`). However, when the user selects a schema from the picker above the view pane, all tables in the view pane show up in the format <schema.table_name> (`public.test_table`). 

This PR modifies TablesListView.swift and ConnectionsDatabasesSidebar.swift to remove the <shema> from the list view so only the table names are visible.