### PR TITLE
Fix for standard SQL syntax 

### DIFF
--- a/PostgresGUI/Views/Components/SyntaxHighlightedEditor.swift
+++ b/PostgresGUI/Views/Components/SyntaxHighlightedEditor.swift
@@ -183,6 +183,15 @@ struct SyntaxHighlightedEditor: NSViewRepresentable {
         textView.isVerticallyResizable = true
         textView.autoresizingMask = [.width]
 
+        // Disable automatic text substitutions for code editing
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.isAutomaticTextCompletionEnabled = false
+        textView.isAutomaticDataDetectionEnabled = false
+        textView.isAutomaticLinkDetectionEnabled = false
+
         // Set up scroll view
         scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = false


### PR DESCRIPTION
 When running a query with a Column Alias (SELECT x **AS "Column Name"**) the query would fail due to a quote substitution feature that was enabled in NSTextView. While Column Aliases aren't the end of the world, this also impacts the `WHERE` portion of a query, as single quotes (`'`) were being replaced with so-called "smart" quotes.

I've disabled these automatic text substitutions. 