### PR TITLE
Feature - Query results stored in session memory

### DIFF
--- a/PostgresGUI/Services/TabService.swift
+++ b/PostgresGUI/Services/TabService.swift
@@ -74,12 +74,8 @@ class TabService: TabServiceProtocol {
         tabState.selectedTableName = viewModel.selectedTableName
         tabState.selectedSchemaFilter = viewModel.selectedSchemaFilter
 
-        // Sync cached results
-        if let results = viewModel.cachedResults {
-            tabState.setCachedResults(results, columnNames: viewModel.cachedColumnNames)
-        } else {
-            tabState.clearCachedResults()
-        }
+        // Note: cachedResults are intentionally NOT persisted to TabState.
+        // Results should only exist in-memory during a session, not across app restarts.
 
         save()
     }
@@ -139,17 +135,11 @@ class TabService: TabServiceProtocol {
         save()
     }
 
-    /// Update cached results for a tab
+    /// Update cached results for a tab (in-memory only, not persisted to disk)
     func updateTabResults(_ viewModel: TabViewModel, results: [TableRow]?, columnNames: [String]?) {
-        DebugLog.print("💾 [TabService] Saving \(results?.count ?? 0) results to tab \(viewModel.id)")
-
-        guard let tabState = fetchTabState(by: viewModel.id) else {
-            DebugLog.print("⚠️ [TabService] Cannot update results - TabState not found")
-            return
-        }
-
-        tabState.setCachedResults(results, columnNames: columnNames)
-        save()
+        DebugLog.print("💾 [TabService] Caching \(results?.count ?? 0) results in-memory for tab \(viewModel.id)")
+        // Results are only stored in the TabViewModel (in-memory), not persisted to TabState
+        // This is intentional - results should not survive app restarts
     }
 
     // MARK: - Legacy Protocol Conformance (for gradual migration)
@@ -228,9 +218,9 @@ class TabService: TabServiceProtocol {
     }
 
     func updateTabResults(_ tab: TabState, results: [TableRow]?, columnNames: [String]?) {
-        DebugLog.print("💾 [TabService] Saving \(results?.count ?? 0) results to tab \(tab.id)")
-        tab.setCachedResults(results, columnNames: columnNames)
-        save()
+        // Results are only stored in-memory (TabViewModel), not persisted to TabState
+        // This is intentional - results should not survive app restarts
+        DebugLog.print("💾 [TabService] Results caching is in-memory only (not persisted)")
     }
 
     func clearSavedQueryId(_ tab: TabState) {

--- a/PostgresGUI/ViewModels/QueryEditorViewModel.swift
+++ b/PostgresGUI/ViewModels/QueryEditorViewModel.swift
@@ -127,6 +127,14 @@ class QueryEditorViewModel {
                     results: result.rows,
                     columnNames: result.columnNames.isEmpty ? nil : result.columnNames
                 )
+
+                // Cache results in-memory for restoration when switching queries
+                if let savedQueryId = appState.query.currentSavedQueryId {
+                    let columnNames = result.columnNames.isEmpty ? [] : result.columnNames
+                    appState.query.cacheResults(for: savedQueryId, rows: result.rows, columnNames: columnNames)
+                    appState.query.lastExecutedAt = Date()
+                    DebugLog.print("💾 [QueryEditorViewModel] Cached \(result.rows.count) results in-memory for SavedQuery")
+                }
             }
 
             // Refresh tables list if query modified schema

--- a/PostgresGUI/ViewModels/SavedQueriesViewModel.swift
+++ b/PostgresGUI/ViewModels/SavedQueriesViewModel.swift
@@ -144,6 +144,7 @@ class SavedQueriesViewModel {
             appState.query.queryError = nil
             appState.query.queryExecutionTime = nil
             appState.query.statusMessage = nil
+            appState.query.lastExecutedAt = nil
 
             DebugLog.print("📝 [SavedQueriesViewModel] Created new query: \(newQuery.name)")
         } catch {
@@ -157,10 +158,19 @@ class SavedQueriesViewModel {
         appState.query.lastSavedAt = query.updatedAt
         appState.query.currentQueryName = query.name
 
-        // Don't clear results - they should remain until user runs a different query
-        // Only clear the status message since it's no longer relevant
-        appState.query.statusMessage = nil
+        // Restore cached results from in-memory cache if available, otherwise clear results pane
+        if let cached = appState.query.getCachedResults(for: query.id) {
+            appState.query.updateQueryResults(cached.rows, columnNames: cached.columnNames)
+            appState.query.lastExecutedAt = cached.executedAt
+            DebugLog.print("📂 [SavedQueriesViewModel] Restored \(cached.rows.count) cached results for: \(query.name)")
+        } else {
+            // Clear results when switching to a query with no cached results
+            appState.query.clearQueryResults()
+            appState.query.lastExecutedAt = nil
+            DebugLog.print("📂 [SavedQueriesViewModel] Cleared results (no cache) for: \(query.name)")
+        }
 
+        appState.query.statusMessage = nil
         DebugLog.print("📂 [SavedQueriesViewModel] Loaded query: \(query.name)")
     }
 

--- a/PostgresGUI/ViewModels/TabViewModel.swift
+++ b/PostgresGUI/ViewModels/TabViewModel.swift
@@ -73,6 +73,8 @@ final class TabViewModel: Identifiable {
     }
 
     /// Create from a TabState (SwiftData model)
+    /// Note: cachedResults are intentionally NOT restored from TabState.
+    /// Results should only persist in-memory during a session, not across app restarts.
     convenience init(from tabState: TabState) {
         self.init(
             id: tabState.id,
@@ -87,8 +89,8 @@ final class TabViewModel: Identifiable {
             selectedTableSchema: tabState.selectedTableSchema,
             selectedTableName: tabState.selectedTableName,
             selectedSchemaFilter: tabState.selectedSchemaFilter,
-            cachedResults: tabState.cachedResults,
-            cachedColumnNames: tabState.cachedColumnNames
+            cachedResults: nil,
+            cachedColumnNames: nil
         )
     }
 

--- a/PostgresGUI/Views/Content/QueryEditorView.swift
+++ b/PostgresGUI/Views/Content/QueryEditorView.swift
@@ -104,10 +104,20 @@ struct QueryEditorView: View {
                 .foregroundColor(.secondary)
                 .font(.system(size: Constants.FontSize.small))
                 .lineLimit(1)
-        } else if let queryName = appState.query.currentQueryName {
-            Text(queryName)
-                .foregroundColor(.secondary)
-                .font(.system(size: Constants.FontSize.small))
+        } else {
+            HStack(spacing: Constants.Spacing.small) {
+                if let lastExecutedAt = appState.query.lastExecutedAt {
+                    Text("Last Executed: \(lastExecutedAt.formatted(date: .abbreviated, time: .shortened))")
+                        .foregroundColor(.secondary)
+                        .font(.system(size: Constants.FontSize.small))
+                }
+
+                if let queryName = appState.query.currentQueryName {
+                    Text(queryName)
+                        .foregroundColor(.secondary)
+                        .font(.system(size: Constants.FontSize.small))
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This update stores the query results for each "Query" in the bottom panel.

When a user runs a query from the bottom panel, the results are stored and the time of the most recent execution is provided on the far right of the query panel. Only the most recent execution of each query is maintained in memory. 

This allows users to browse between queries and see each set of results without needing to re-execute a query.

