### PR TITLE
Remove query name from toolbar status view

### DIFF
--- a/PostgresGUI/Views/Content/QueryEditorView.swift
+++ b/PostgresGUI/Views/Content/QueryEditorView.swift
@@ -104,20 +104,10 @@ struct QueryEditorView: View {
                 .foregroundColor(.secondary)
                 .font(.system(size: Constants.FontSize.small))
                 .lineLimit(1)
-        } else {
-            HStack(spacing: Constants.Spacing.small) {
-                if let lastExecutedAt = appState.query.lastExecutedAt {
-                    Text("Last Executed: \(lastExecutedAt.formatted(date: .abbreviated, time: .shortened))")
-                        .foregroundColor(.secondary)
-                        .font(.system(size: Constants.FontSize.small))
-                }
-
-                if let queryName = appState.query.currentQueryName {
-                    Text(queryName)
-                        .foregroundColor(.secondary)
-                        .font(.system(size: Constants.FontSize.small))
-                }
-            }
+        } else if let lastExecutedAt = appState.query.lastExecutedAt {
+            Text("Last Executed: \(lastExecutedAt.formatted(date: .abbreviated, time: .shortened))")
+                .foregroundColor(.secondary)
+                .font(.system(size: Constants.FontSize.small))
         }
     }
 }


### PR DESCRIPTION
Removing the query name from the query editor toolbar to make room for "Last executed" info.

Query name can already be seen from the query list on the left side.

<img width="2158" height="1638" alt="screenshot-2026-01-23_18-08-11@2x" src="https://github.com/user-attachments/assets/b32e550d-7f0f-4a21-b980-18ec26e12385" />
