### PR TITLE
Extend query timeout and cancel query option.

### DIFF
--- a/PostgresGUI/Utilities/Constants.swift
+++ b/PostgresGUI/Utilities/Constants.swift
@@ -61,6 +61,7 @@ enum Constants {
     // Timeouts
     enum Timeout {
         /// Default timeout for database operations (queries, table loading)
-        static let databaseOperation: TimeInterval = 15.0
+        /// Set to 5 minutes to allow long-running queries while still providing safety
+        static let databaseOperation: TimeInterval = 300.0
     }
 }

--- a/PostgresGUI/Views/Content/QueryResultsView.swift
+++ b/PostgresGUI/Views/Content/QueryResultsView.swift
@@ -85,11 +85,19 @@ struct QueryResultsView: View {
     var onDeleteKeyPressed: (() -> Void)?
     var onSpaceKeyPressed: (() -> Void)?
 
+    /// Whether the current query (for this saved query) is executing
+    private var isCurrentQueryExecuting: Bool {
+        appState.query.executingSavedQueryId == appState.query.currentSavedQueryId &&
+        appState.query.executingSavedQueryId != nil
+    }
+
     var body: some View {
         VStack(spacing: 0) {
-            // Results or error display
+            // Results or error display - greyed out during execution
             resultsContent
                 .id(dateFormatSetting) // Force refresh when date format changes
+                .opacity(isCurrentQueryExecuting ? 0.4 : 1.0)
+                .allowsHitTesting(!isCurrentQueryExecuting)
 
             // Pagination row (only show if there's more than one page)
             if appState.query.currentPage > 0 || appState.query.hasNextPage {
@@ -125,10 +133,6 @@ struct QueryResultsView: View {
                     .foregroundColor(.secondary)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if appState.query.isExecutingQuery {
-            // Show loading state while query executes
-            ProgressView()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if appState.query.queryResults.isEmpty {
             // Show empty table with headers if column names are available
             if let columnNames = getColumnNames(), !columnNames.isEmpty {

--- a/PostgresGUI/Views/Sidebar/SavedQueryRowView.swift
+++ b/PostgresGUI/Views/Sidebar/SavedQueryRowView.swift
@@ -6,6 +6,8 @@
 import SwiftUI
 
 struct SavedQueryRowView: View {
+    @Environment(AppState.self) private var appState
+
     let query: SavedQuery
     let isSelected: Bool
     let selectedQueryCount: Int
@@ -19,6 +21,11 @@ struct SavedQueryRowView: View {
 
     @State private var isHovered = false
     @State private var isButtonHovered = false
+
+    /// Whether this query is currently executing
+    private var isExecuting: Bool {
+        appState.query.executingSavedQueryId == query.id
+    }
 
     private var showMultiSelectActions: Bool {
         isSelected && (selectedQueryCount > 1 || selectedFolderCount > 0)
@@ -34,8 +41,15 @@ struct SavedQueryRowView: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 8) {
-            Image(systemName: "doc.text")
-                .foregroundColor(.secondary)
+            // Show loading indicator or document icon
+            if isExecuting {
+                ProgressView()
+                    .scaleEffect(0.5)
+                    .frame(width: 16, height: 16)
+            } else {
+                Image(systemName: "doc.text")
+                    .foregroundColor(.secondary)
+            }
             Text(query.name)
                 .lineLimit(1)
             Spacer()


### PR DESCRIPTION
This change adds an option to cancel an in-progress query, dissociated the results panel with the running query until the query completes (clears the results panel and waits for the updated data from the running query), and provides a query runtime at the top right of the query panel until the query is complete. Along that same vein, it also provides an animation next to the query that's being run in the query panel. This helps users who may be writing additional queries while they await results from the one that's running.

This also extends the query timeout to 5 minutes, although I think changing this to a user-configurable setting would provide a lot more usefulness.  
<img width="1510" height="182" alt="image" src="https://github.com/user-attachments/assets/30bf783a-46c6-4214-952a-ebfa7d04c508" />
