### PR TITLE
feat: add automated local build and DMG packaging scripts with corres…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,8 @@ fastlane/test_output
 .claude
 .cursor
 
+# OS
+.DS_Store
+
+# Build files
+*.dmg

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@
 
 4. Build and run with `Cmd+R`
 
+### Automated Local Build
+
+If you don't want to open Xcode to configure code signing manually, you can use the provided script to set your Apple Developer Team ID and run the build directly from the terminal:
+
+1. Apply your Team ID and a custom Bundle Identifier prefix:
+   ```bash
+   ./clean_pbxproj.sh YOUR_TEAM_ID com.yourname
+   ```
+   *(You can find your 10-character Team ID in your Apple Developer account)*
+
+2. Build the app and generate the DMG:
+   ```bash
+   ./build_dmg.sh
+   ```
 ### Submitting Pull Requests
 
 When you select your team in step 3, Xcode modifies `project.pbxproj` with your team ID. **Do not include this change in your pull request.**

--- a/build_dmg.sh
+++ b/build_dmg.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Stop on first error
+set -e
+
+echo "🚀 Starting PostgresGUI build process..."
+
+# Clean and build the project
+# The generated files will be output to the local "./build" folder
+xcodebuild -project PostgresGUI.xcodeproj \
+           -scheme PostgresGUI \
+           -configuration Release \
+           -derivedDataPath build/ \
+           clean build
+
+# Define paths
+APP_PATH="build/Build/Products/Release/PostgresGUI.app"
+
+# Check if the build was successful and generated the .app
+if [ ! -d "$APP_PATH" ]; then
+    echo "❌ Error: App not found at $APP_PATH. The build may have failed."
+    exit 1
+fi
+
+# Extract version from the built app's Info.plist
+APP_VERSION=$(defaults read "$(pwd)/$APP_PATH/Contents/Info.plist" CFBundleShortVersionString)
+DMG_NAME="PostgresGUI-${APP_VERSION}.dmg"
+
+echo "✅ Build completed successfully!"
+echo "📦 Packaging into $DMG_NAME..."
+
+# Remove previous DMG if it exists
+if [ -f "$DMG_NAME" ]; then
+    rm "$DMG_NAME"
+fi
+
+# Check if the user has create-dmg installed (creates nicer DMGs)
+if command -v create-dmg &> /dev/null; then
+    echo "✨ Using 'create-dmg'..."
+    create-dmg \
+      --volname "PostgresGUI" \
+      --window-pos 200 120 \
+      --window-size 600 400 \
+      --icon-size 100 \
+      --icon "PostgresGUI.app" 150 190 \
+      --hide-extension "PostgresGUI.app" \
+      --app-drop-link 450 185 \
+      "$DMG_NAME" \
+      "$APP_PATH"
+else
+    echo "⚠️ 'create-dmg' not found. (Recommended: brew install create-dmg)"
+    echo "⚙️ Using native macOS 'hdiutil' as fallback..."
+    hdiutil create -volname "PostgresGUI" -srcfolder "$APP_PATH" -ov -format UDZO "$DMG_NAME"
+fi
+
+echo "🎉 Done! The file $DMG_NAME was successfully created."

--- a/clean_pbxproj.sh
+++ b/clean_pbxproj.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Stop on first error
+set -e
+
+PBXPROJ="PostgresGUI.xcodeproj/project.pbxproj"
+
+if [ ! -f "$PBXPROJ" ]; then
+    echo "❌ File $PBXPROJ not found. Please run this script from the project root."
+    exit 1
+fi
+
+# Define variables using arguments or defaults
+TEAM_ID=${1:-""}
+BUNDLE_PREFIX=${2:-"com.localbuild"}
+
+echo "🧹 Cleaning up project credentials..."
+
+if [ -z "$TEAM_ID" ]; then
+    echo "⚠️ No Team ID provided. Removing original Team ID..."
+    sed -i '' 's/DEVELOPMENT_TEAM = 75KGPEX6ZF;/DEVELOPMENT_TEAM = "";/g' "$PBXPROJ"
+else
+    echo "🔑 Applying your Team ID ($TEAM_ID)..."
+    sed -i '' "s/DEVELOPMENT_TEAM = 75KGPEX6ZF;/DEVELOPMENT_TEAM = $TEAM_ID;/g" "$PBXPROJ"
+    sed -i '' "s/DEVELOPMENT_TEAM = \"\";/DEVELOPMENT_TEAM = $TEAM_ID;/g" "$PBXPROJ"
+fi
+
+echo "📦 Applying Bundle Identifier ($BUNDLE_PREFIX)..."
+sed -i '' "s/PRODUCT_BUNDLE_IDENTIFIER = com.mghazi./PRODUCT_BUNDLE_IDENTIFIER = $BUNDLE_PREFIX./g" "$PBXPROJ"
+
+echo "✅ File project.pbxproj successfully updated!"
+
+if [ -z "$TEAM_ID" ]; then
+    echo "⚠️ IMPORTANT: Because no Team ID was provided, you MUST open Xcode to select your Personal Team before building."
+else
+    echo "🚀 Ready to build! You can now run ./build_dmg.sh without opening Xcode."
+fi


### PR DESCRIPTION
Here is a brief summary of what each .sh script does:

clean_pbxproj.sh: Prepares the Xcode project for local development by stripping out the original author's credentials (Team ID and Bundle Identifier). It replaces them with your own credentials (if passed as parameters) or leaves them empty, preventing code signing errors when trying to build the project.

build_dmg.sh: Automates the entire release process. It uses Apple's command-line tools (xcodebuild) to compile the source code, signs the application with your developer credentials, and packages the final app into a distributable .dmg file ready for installation.