### PR TITLE
fix: allow automatic provisioning updates in xcodebuild

### DIFF
--- a/build_dmg.sh
+++ b/build_dmg.sh
@@ -11,6 +11,7 @@ xcodebuild -project PostgresGUI.xcodeproj \
            -scheme PostgresGUI \
            -configuration Release \
            -derivedDataPath build/ \
+           -allowProvisioningUpdates \
            clean build
 
 # Define paths


### PR DESCRIPTION
Description: Context: After the latest merge, the CLI build script (build_dmg.sh) started failing with the following error: "Automatic signing is disabled and unable to generate a profile".

What was changed? Added the -allowProvisioningUpdates flag to the xcodebuild command in build_dmg.sh.

Why was it changed? By default, xcodebuild in the terminal cannot communicate with the Apple Developer Portal to fetch missing provisioning profiles. This flag grants it permission to automatically generate or download the required profiles during the build process, effectively fixing the build failure introduced after the last merge.

BEFORE

`error: No profiles for 'com.carlos.PostgresGUI' were found: Xcode couldn't find any Mac App Development provisioning profiles matching 'com.carlos.PostgresGUI'. Automatic signing is disabled and unable to generate a profile. To enable automatic signing, pass -allowProvisioningUpdates to xcodebuild. (in target 'PostgresGUI' from project 'PostgresGUI')`