### PR TITLE
Copy selected result rows as CSV with Cmd+C

### DIFF
--- a/PostgresGUI/Utilities/CSVExporter.swift
+++ b/PostgresGUI/Utilities/CSVExporter.swift
@@ -40,6 +40,20 @@ enum CSVExporter {
         return csvLines.joined(separator: "\n")
     }
 
+    /// Converts the selected subset of rows to CSV, preserving the order of `rows`
+    /// - Parameters:
+    ///   - rows: Rows in display order (already sorted and filtered by the view)
+    ///   - selectedIDs: IDs of the rows to include
+    ///   - columns: Column order for the output
+    /// - Returns: CSV formatted string, or "" when nothing is selected
+    static func csvForSelection(
+        rows: [TableRow],
+        selectedIDs: Set<TableRow.ID>,
+        columns: [String]?
+    ) -> String {
+        toCSV(rows: rows.filter { selectedIDs.contains($0.id) }, columns: columns)
+    }
+
     /// Escapes a field for CSV format according to RFC 4180
     /// - Parameter field: The field value to escape
     /// - Returns: Properly escaped CSV field

--- a/PostgresGUI/Views/Components/Content/QueryResultsComponent.swift
+++ b/PostgresGUI/Views/Components/Content/QueryResultsComponent.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import AppKit
 
 // MARK: - Table Row Comparator
 
@@ -212,6 +213,11 @@ struct QueryResultsComponent: View {
                 }
                 return .ignored
             }
+            // Cmd+C is consumed by the standard Edit > Copy menu item, which sends
+            // `copy:` down the responder chain. `.copyable` is what answers it;
+            // `.onCopyCommand` and `.onKeyPress` never see the key at all.
+            // An empty array means no selection, and Copy stays greyed out.
+            .copyable(copyableCSV)
         }
     }
 
@@ -228,6 +234,17 @@ struct QueryResultsComponent: View {
             }
         }
         .id(tableIdentity)
+    }
+
+    /// The selected rows as a single CSV string, or empty when nothing is selected.
+    private var copyableCSV: [String] {
+        guard !selectedRowIDs.isEmpty else { return [] }
+        let csv = CSVExporter.csvForSelection(
+            rows: sortedResults,
+            selectedIDs: selectedRowIDs,
+            columns: columnNames
+        )
+        return csv.isEmpty ? [] : [csv]
     }
 
     private var filteredResults: [TableRow] {

--- a/PostgresGUITests/CSVExporterTests.swift
+++ b/PostgresGUITests/CSVExporterTests.swift
@@ -242,6 +242,66 @@ struct CSVExporterTests {
         }
     }
 
+    // MARK: - Selection Tests
+
+    @Suite("Selection")
+    struct SelectionTests {
+
+        @Test func copiesOnlySelectedRowsInGivenOrder() {
+            let grace = TableRow(values: ["name": "Grace", "age": "22"])
+            let eve = TableRow(values: ["name": "Eve", "age": "29"])
+            let alice = TableRow(values: ["name": "Alice", "age": "30"])
+            let frank = TableRow(values: ["name": "Frank", "age": "38"])
+            let bob = TableRow(values: ["name": "Bob", "age": "25"])
+            let dave = TableRow(values: ["name": "Dave", "age": "45"])
+            let carol = TableRow(values: ["name": "Carol", "age": "41"])
+
+            // Rows arrive in display order (already sorted/filtered by the view),
+            // and the selection is an unordered Set. 5 of the 7 rows are selected
+            // (120 possible orderings of the selected IDs), with two unselected
+            // rows interspersed (Grace at the start, Bob in the middle) — an
+            // implementation that iterated the Set instead of filtering `rows`
+            // would both include the unselected rows and get the order wrong
+            // almost certainly, rather than by coincidence.
+            let result = CSVExporter.csvForSelection(
+                rows: [grace, eve, alice, frank, bob, dave, carol],
+                selectedIDs: [eve.id, alice.id, frank.id, dave.id, carol.id],
+                columns: ["name", "age"]
+            )
+
+            #expect(result == "name,age\nEve,29\nAlice,30\nFrank,38\nDave,45\nCarol,41")
+        }
+
+        @Test func returnsEmptyStringWhenNothingIsSelected() {
+            let alice = TableRow(values: ["name": "Alice", "age": "30"])
+
+            let result = CSVExporter.csvForSelection(
+                rows: [alice],
+                selectedIDs: [],
+                columns: ["name", "age"]
+            )
+
+            #expect(result == "")
+        }
+
+        @Test func ignoresSelectedIDsForRowsNoLongerPresentInRows() {
+            let alice = TableRow(values: ["name": "Alice", "age": "30"])
+            let bob = TableRow(values: ["name": "Bob", "age": "25"])
+            // Simulates a row the user selected before narrowing the search
+            // filter — it's no longer in the displayed `rows` array, but its ID
+            // is still in `selectedIDs` until the selection is explicitly cleared.
+            let phantom = TableRow(values: ["name": "Phantom", "age": "99"])
+
+            let result = CSVExporter.csvForSelection(
+                rows: [alice, bob],
+                selectedIDs: [alice.id, phantom.id, bob.id],
+                columns: ["name", "age"]
+            )
+
+            #expect(result == "name,age\nAlice,30\nBob,25")
+        }
+    }
+
     // MARK: - Real-world Scenarios
 
     @Suite("Real-world Scenarios")


### PR DESCRIPTION
## What

Select one or more rows in the query results table and press <kbd>⌘C</kbd> to copy them to the clipboard as CSV — the behaviour PyCharm and DataGrip have in their data editors.

- Header row included, matching the existing "Download CSV" export.
- Rows come out in **display order**, so the active column sort and the search filter both apply.
- Raw database values, not the display-formatted ones — a timestamp copies as `2025-11-29T14:03:11Z` regardless of the date-format preference, because "3 days ago" is useless in a spreadsheet.
- `NULL` copies as an empty field, consistent with the existing CSV export.
- With nothing selected, Edit ▸ Copy stays greyed out and the clipboard is left untouched.
- ⌘C is unchanged everywhere else — the query editor and text fields keep their own copy.

## How

`CSVExporter.csvForSelection(rows:selectedIDs:columns:)` filters the displayed rows by the selection and delegates to the existing `toCSV`, so escaping, header emission and the empty case are all inherited. `toCSV` itself is untouched, so its existing callers (`TableContextMenuViewModel`, `JSONViewerView`) are unaffected.

The view side is one modifier on the results `Table`:

```swift
.copyable(copyableCSV)
```

### Why `.copyable` and not `.onCopyCommand`

Worth recording, because the obvious choice does not work. On macOS, ⌘C is claimed by the standard **Edit ▸ Copy** menu item, which sends `copy:` down the responder chain:

- `.onCopyCommand` never fires for a SwiftUI `Table` — ⌘C just produces the AppKit beep of an unhandled `copy:`, and nothing reaches the clipboard.
- `.onKeyPress` never sees the keystroke either, because the menu item takes it first.
- `.copyable` answers `copy:`, so it works and lights up Edit ▸ Copy for free.

## Testing

Three unit tests in `CSVExporterTests`:

- 5 of 7 rows selected with two unselected rows interspersed, asserting the exact CSV — with that many rows an implementation iterating the unordered selection `Set` instead of filtering the rows array would get the order wrong essentially every time, rather than passing by coincidence.
- Empty selection returns `""`.
- Selected IDs with no matching row are ignored — the state left behind when the search filter narrows while a selection is live.

`xcodebuild test -only-testing:PostgresGUITests/CSVExporterTests` → `** TEST SUCCEEDED **`.

Verified by hand in the running app: single row, multiple rows, with a column sort active, with the search filter active, and ⌘C still working normally in the query editor.

Note for maintainers: the pre-existing failures in `AppStateTests`, `QueryResultNormalizerTests` and `ConnectionSidebarViewModelTests` are unrelated to this change — they fail identically at `8d22b89`, before this branch.

## Disclosure

This feature was built end to end with [Claude Code](https://claude.com/claude-code) — design, implementation, tests and this description. A human reviewed it and verified the behaviour by hand in the running app; the ⌘C wiring in particular was rewritten after manual testing proved the first approach (`.onCopyCommand`) silently did nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016c54WtjsUUQQoj3vAH6jok
